### PR TITLE
/time command: Added sunrise and sunset, fixing RAW times used 

### DIFF
--- a/src/main/java/com/dinnerbone/bukkit/scrap/ScrapPlayerListener.java
+++ b/src/main/java/com/dinnerbone/bukkit/scrap/ScrapPlayerListener.java
@@ -112,10 +112,16 @@ public class ScrapPlayerListener extends PlayerListener {
             	} else if (timeStr.equalsIgnoreCase("day")) {
             		server.setTime(startOfDay);
             		event.setCancelled(true);
-            	} else if (timeStr.equalsIgnoreCase("night")) {
-            		server.setTime(startOfDay + 13000);
-            		event.setCancelled(true);
-            	} else if (timeStr.startsWith("=")) {
+                } else if (timeStr.equalsIgnoreCase("sunset")) {
+                    server.setTime(startOfDay +  12000);
+                    event.setCancelled(true);
+                } else if (timeStr.equalsIgnoreCase("night")) {
+                    server.setTime(startOfDay + 13800);
+                    event.setCancelled(true);
+                } else if (timeStr.equalsIgnoreCase("sunrise")) {
+                    server.setTime(startOfDay + 22200);
+                    event.setCancelled(true);
+                } else if (timeStr.startsWith("=")) {
             		try {
             		server.setTime(Long.parseLong(timeStr.substring(1)));
             		event.setCancelled(true);


### PR DESCRIPTION
I created a short and sweet patch that corrects the RAW time values used for setting to day and night, as well as allow the /time command to set to all sunrise and sunset.

All calculations are based on the timing for day, sunset, night, and sunrise on the MC wiki, and are the same as used in my populer time plugins.
